### PR TITLE
Add 1 more path configuration

### DIFF
--- a/video5/line.html
+++ b/video5/line.html
@@ -20,6 +20,7 @@ d3.json("./example2.json", function(error, data) {
     svg.append("path")
             .attr("d", line(data))
             .style("stroke", "black")
+            .attr("fill", "none")
 
 });
 


### PR DESCRIPTION
When I modify example2.json file to other value, the result didn't meet my expectation. In the SVG, the area are filled with black.  

After searching online, I think it will be better if add 1 more configuration to path: `.attr('fill', 'none')`
